### PR TITLE
Add flag for allowing TLS connections to verify the server CA

### DIFF
--- a/src/clientoptions.rs
+++ b/src/clientoptions.rs
@@ -180,7 +180,7 @@ impl MqttOptions {
         self
     }
 
-    /// Set flag to ignore server CA verification during TLS connection
+    /// Set flag to determine whether or not to verify server CA during TLS connection
     pub fn set_should_verify_ca(mut self, should_verify_ca: bool) -> Self
     {
         self.verify_ca = should_verify_ca;

--- a/src/clientoptions.rs
+++ b/src/clientoptions.rs
@@ -19,6 +19,7 @@ pub struct MqttOptions {
     // wait time for ack beyond which packet(publish/subscribe) will be resent
     pub queue_timeout: u16,
     pub ca: Option<PathBuf>,
+    pub verify_ca: bool,
     pub client_cert: Option<(PathBuf, PathBuf)>,
 }
 
@@ -39,6 +40,7 @@ impl Default for MqttOptions {
             sub_q_len: 5,
             queue_timeout: 60,
             ca: None,
+            verify_ca: true,
             client_cert: None,
         }
     }
@@ -175,6 +177,13 @@ impl MqttOptions {
         where P: AsRef<Path>
     {
         self.ca = Some(cafile.as_ref().to_path_buf());
+        self
+    }
+
+    /// Set flag to ignore server CA verification during TLS connection
+    pub fn set_should_verify_ca(mut self, should_verify_ca: bool) -> Self
+    {
+        self.verify_ca = should_verify_ca;
         self
     }
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -289,10 +289,10 @@ impl Connection {
                 let stream = match self.opts.ca {
                     Some(ref ca) => {
                         if let Some((ref crt, ref key)) = self.opts.client_cert {
-                            let ssl_ctx: SslContext = try!(SslContext::new(ca, Some((crt, key))));
+                            let ssl_ctx: SslContext = try!(SslContext::new(ca, Some((crt, key)), self.opts.verify_ca));
                             NetworkStream::Tls(try!(ssl_ctx.connect(stream)))
                         } else {
-                            let ssl_ctx: SslContext = try!(SslContext::new(ca, None::<(String, String)>));
+                            let ssl_ctx: SslContext = try!(SslContext::new(ca, None::<(String, String)>, self.opts.verify_ca));
                             NetworkStream::Tls(try!(ssl_ctx.connect(stream)))
                         }
                     }


### PR DESCRIPTION
@kteza1 While using this library I noticed the TLS connection is hard-coded to ignore the server's certificate. I added a flag to control this behavior instead, which the user can set with `set_should_verify_ca(bool)`. It defaults to `true`, so this may break some integration tests that relied on the previous default permissive behavior. Right now the only failing `cargo test` is the same failure from master. Let me know what you think.