### PR TITLE
Minor idiomatic refactors and fix missing mod

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -29,7 +29,7 @@ pub type PublishSendableFn = Box<Fn(Message) + Send + Sync>;
 pub struct MqttClient {
     pub opts: MqttOptions,
     pub last_pkid: PacketIdentifier,
-    pub nw_request_tx: Option<Sender<NetworkRequest>>,
+    pub nw_request_tx: Sender<NetworkRequest>,
 }
 
 impl MqttClient {
@@ -43,36 +43,30 @@ impl MqttClient {
         unreachable!("Cannot lookup address");
     }
 
-    pub fn new(opts: MqttOptions) -> Self {
-        // TODO: Move state initialization to MqttClient constructor
-        MqttClient {
-            last_pkid: PacketIdentifier(0),
-            opts: opts,
-            nw_request_tx: None,
-        }
-    }
-
     /// Connects to the broker and starts an event loop in a new thread.
     /// Returns 'Request' and handles reqests from it.
     /// Also handles network events, reconnections and retransmissions.
-    pub fn start(mut self) -> Result<Self> {
+    pub fn connect(opts: MqttOptions) -> Result<Self> {
         let (nw_request_tx, nw_request_rx) = channel::<NetworkRequest>();
-        self.nw_request_tx = Some(nw_request_tx);
-
-        let opts = self.opts.clone();
-
+        // let opts = opts.clone();
+        let addr = Self::lookup_ipv4(opts.addr.as_str());
+        let mut connection = Connection::start(addr, opts.clone(), nw_request_rx, None, None)?;
         // This thread handles network reads (coz they are blocking) and
         // and sends them to event loop thread to handle mqtt state.
-        let addr = Self::lookup_ipv4(opts.addr.as_str());
-        let mut connection = Connection::start(addr, opts, nw_request_rx, None, None)?;
         thread::spawn(move || -> Result<()> {
             let _ = connection.run();
             error!("Network Thread Stopped !!!!!!!!!");
             Ok(())
         });
-        Ok(self)
+        
+        let client = MqttClient {
+            last_pkid: PacketIdentifier(0),
+            opts: opts,
+            nw_request_tx: nw_request_tx,
+        };
+        
+        Ok(client)
     }
-
 
     fn subscribe(&mut self, topics: Vec<(&str, QualityOfService)>) -> Result<()> {
          let mut sub_topics = vec![];
@@ -81,14 +75,12 @@ impl MqttClient {
             sub_topics.push(topic);
         }
 
-        let nw_request_tx = self.nw_request_tx.as_ref().unwrap();
-        try!(nw_request_tx.send(NetworkRequest::Subscribe(sub_topics)));
+        try!(self.nw_request_tx.send(NetworkRequest::Subscribe(sub_topics)));
         Ok(())
     }
 
     fn publish0(&self, message: Message) -> Result<()> {
-        let nw_request_tx = self.nw_request_tx.as_ref().unwrap();
-        nw_request_tx.send(NetworkRequest::Publish(message))?;
+        self.nw_request_tx.send(NetworkRequest::Publish(message))?;
         Ok(())
     }
 
@@ -97,8 +89,7 @@ impl MqttClient {
         let PacketIdentifier(pkid) = self._next_pkid();
         message.set_pkid(pkid);
 
-        let nw_request_tx = self.nw_request_tx.as_ref().unwrap();
-        nw_request_tx.send(NetworkRequest::Publish(message))?;
+        self.nw_request_tx.send(NetworkRequest::Publish(message))?;
         Ok(())
     }
 
@@ -107,8 +98,7 @@ impl MqttClient {
         let PacketIdentifier(pkid) = self._next_pkid();
         message.set_pkid(pkid);
 
-        let nw_request_tx = self.nw_request_tx.as_ref().unwrap();
-        try!(nw_request_tx.send(NetworkRequest::Publish(message)));
+        try!(self.nw_request_tx.send(NetworkRequest::Publish(message)));
         Ok(())
     }
 
@@ -134,14 +124,12 @@ impl MqttClient {
     }
 
     pub fn disconnect(&self) -> Result<()> {
-        let nw_request_tx = self.nw_request_tx.as_ref().unwrap();
-        try!(nw_request_tx.send(NetworkRequest::Disconnect));
+        try!(self.nw_request_tx.send(NetworkRequest::Disconnect));
         Ok(())
     }
 
     pub fn shutdown(&self) -> Result<()> {
-        let nw_request_tx = self.nw_request_tx.as_ref().unwrap();
-        try!(nw_request_tx.send(NetworkRequest::Shutdown));
+        try!(self.nw_request_tx.send(NetworkRequest::Shutdown));
         Ok(())
     }
 
@@ -207,7 +195,7 @@ mod test {
     #[test]
     fn next_pkid_roll() {
         let client_options = MqttOptions::new();
-        let mut mq_client = MqttClient::new(client_options);
+        let mut mq_client = MqttClient::connect(client_options).unwrap();
 
         for i in 0..65536 {
             mq_client._next_pkid();

--- a/src/client.rs
+++ b/src/client.rs
@@ -179,7 +179,6 @@ impl MqttClient {
     }
 }
 
-
 // @@@@@@@@@@@@~~~~~~~UNIT TESTS ~~~~~~~~~@@@@@@@@@@@@
 
 #[cfg(test)]
@@ -194,13 +193,16 @@ mod test {
 
     #[test]
     fn next_pkid_roll() {
-        let client_options = MqttOptions::new();
-        let mut mq_client = MqttClient::connect(client_options).unwrap();
-
-        for i in 0..65536 {
-            mq_client._next_pkid();
+        let client_options = MqttOptions::new().broker("test.mosquitto.org:1883");
+        match MqttClient::connect(client_options) {
+            Ok(mut mq_client) => {
+                for i in 0..65536 {
+                    mq_client._next_pkid();
+                }
+                assert_eq!(PacketIdentifier(1), mq_client.last_pkid);
+            }
+            Err(e) => panic!("{:?}", e),
         }
 
-        assert_eq!(PacketIdentifier(1), mq_client.last_pkid);
     }
 }

--- a/src/clientoptions.rs
+++ b/src/clientoptions.rs
@@ -10,7 +10,7 @@ pub struct MqttOptions {
     pub client_id: Option<String>,
     pub username: Option<String>,
     pub password: Option<String>,
-    pub reconnect: Option<u16>,
+    pub reconnect: u16,
     pub will: Option<(String, String)>,
     pub will_qos: QualityOfService,
     pub will_retain: bool,
@@ -32,7 +32,7 @@ impl Default for MqttOptions {
             client_id: None,
             username: None,
             password: None,
-            reconnect: Some(5),
+            reconnect: 5,
             will: None,
             will_qos: QualityOfService::Level0,
             will_retain: false,
@@ -45,7 +45,6 @@ impl Default for MqttOptions {
         }
     }
 }
-
 
 impl MqttOptions {
     /// Creates a new `MqttOptions` object which is used to set connection
@@ -148,7 +147,7 @@ impl MqttOptions {
     /// By default, no retry will happen
     // TODO: Rename
     pub fn set_reconnect(mut self, dur: u16) -> Self {
-        self.reconnect = Some(dur);
+        self.reconnect = dur;
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,12 +71,10 @@ mod stream;
 mod message;
 mod clientoptions;
 mod connection;
-mod request;
 mod client;
 
 pub use error::{Error, Result};
 pub use clientoptions::MqttOptions;
 pub use mqtt::QualityOfService as QoS;
 pub use client::MqttClient;
-pub use request::MqRequest;
 pub use message::Message;

--- a/tests/testsuite.rs
+++ b/tests/testsuite.rs
@@ -24,7 +24,7 @@ fn inital_tcp_connect_failure() {
         .broker("localhost:9999");
 
     // Connects to a broker and returns a `request`
-    let request = MqttClient::new(client_options)
+    let request = MqttClient::connect(client_options)
         .start()
         .expect("Couldn't start");
 }

--- a/tests/testsuite.rs
+++ b/tests/testsuite.rs
@@ -24,9 +24,7 @@ fn inital_tcp_connect_failure() {
         .broker("localhost:9999");
 
     // Connects to a broker and returns a `request`
-    let request = MqttClient::connect(client_options)
-        .start()
-        .expect("Couldn't start");
+    let request = MqttClient::connect(client_options).expect("Couldn't start");
 }
 
 // After connecting to tcp, should timeout error if it didn't receive CONNACK
@@ -36,7 +34,7 @@ fn inital_tcp_connect_failure() {
 fn connect_timeout_failure() {
     // TODO: Change the host to remote host and fix blocks
     let client_options = MqttOptions::new().broker("localhost:9999");
-    let request = MqttClient::new(client_options).start().expect("Couldn't restart");
+    let request = MqttClient::connect(client_options).expect("Couldn't restart");
 }
 
 // Shouldn't try to reconnect if there is a connection problem
@@ -50,7 +48,7 @@ fn inital_mqtt_connect_failure() {
 
 
     // Connects to a broker and returns a `request`
-    let client = MqttClient::new(client_options).start().expect("Couldn't start");
+    let client = MqttClient::connect(client_options).expect("Couldn't start");
 }
 
 // #[test]


### PR DESCRIPTION
Update
The [latest commit](https://github.com/Ather-Energy/RuMqtt/pull/36/commits/21dd442c2b993823e3434f45def927f941982cde), makes the `next_pkid_roll` pass again using the broker addr as `test.mosquitto.org`.