### PR TITLE
Upgrade to openssl 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ rand = "0.3"
 time = "0.1"
 threadpool = "1.3"
 mqtt-protocol = "0.1"
-openssl = { version = "0.8", features = ["tlsv1_2"] }
+openssl = { version = "0.9" }
 
 [dev-dependencies]
 env_logger = "0.3"

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -322,10 +322,10 @@ impl Connection {
                     Some(ref ca) => {
                         if let Some((ref crt, ref key)) = self.opts.client_cert {
                             let ssl_ctx: SslContext = try!(SslContext::new(ca, Some((crt, key)), self.opts.verify_ca));
-                            NetworkStream::Tls(try!(ssl_ctx.connect(stream)))
+                            NetworkStream::Tls(try!(ssl_ctx.connect(&self.opts.addr, stream)))
                         } else {
                             let ssl_ctx: SslContext = try!(SslContext::new(ca, None::<(String, String)>, self.opts.verify_ca));
-                            NetworkStream::Tls(try!(ssl_ctx.connect(stream)))
+                            NetworkStream::Tls(try!(ssl_ctx.connect(&self.opts.addr, stream)))
                         }
                     }
                     None => NetworkStream::Tcp(stream),

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -64,6 +64,7 @@ pub type PublishSendableFn = Box<Fn(Message) + Send + Sync>;
 
 pub struct Connection {
     pub addr: SocketAddr,
+    pub domain: String,
     pub opts: MqttOptions,
     pub stream: NetworkStream,
     pub nw_request_rx: Receiver<NetworkRequest>,
@@ -111,6 +112,7 @@ impl Connection {
 
         let mut connection = Connection {
             addr: addr,
+            domain: opts.addr.split(":").map(str::to_string).next().unwrap_or_default(),
             opts: opts,
             stream: NetworkStream::None,
             nw_request_rx: nw_request_rx,
@@ -322,10 +324,10 @@ impl Connection {
                     Some(ref ca) => {
                         if let Some((ref crt, ref key)) = self.opts.client_cert {
                             let ssl_ctx: SslContext = try!(SslContext::new(ca, Some((crt, key)), self.opts.verify_ca));
-                            NetworkStream::Tls(try!(ssl_ctx.connect(&self.opts.addr, stream)))
+                            NetworkStream::Tls(try!(ssl_ctx.connect(&self.domain, stream)))
                         } else {
                             let ssl_ctx: SslContext = try!(SslContext::new(ca, None::<(String, String)>, self.opts.verify_ca));
-                            NetworkStream::Tls(try!(ssl_ctx.connect(&self.opts.addr, stream)))
+                            NetworkStream::Tls(try!(ssl_ctx.connect(&self.domain, stream)))
                         }
                     }
                     None => NetworkStream::Tcp(stream),

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -38,8 +38,8 @@ impl SslContext {
         Ok(SslContext { inner: Arc::new(ctx_builder.build()) })
     }
 
-    pub fn connect(&self, stream: TcpStream) -> Result<SslStream> {
-        let ssl_stream = try!(ssl::SslConnector::danger_connect_without_providing_domain_for_certificate_verification_and_server_name_indication(&*self.inner, stream));
+    pub fn connect(&self, domain: &str, stream: TcpStream) -> Result<SslStream> {
+        let ssl_stream = try!(ssl::SslConnector::connect(&*self.inner, domain, stream));
         Ok(ssl_stream)
     }
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -6,15 +6,14 @@ use std::path::Path;
 use std::time::Duration;
 
 use openssl::ssl::{self, SslMethod, SSL_VERIFY_NONE, SSL_VERIFY_PEER};
-use openssl::x509::X509FileType;
+use openssl::x509::X509_FILETYPE_PEM;
 
 pub type SslStream = ssl::SslStream<TcpStream>;
 
 use error::Result;
 
-#[derive(Debug)]
 pub struct SslContext {
-    pub inner: Arc<ssl::SslContext>,
+    pub inner: Arc<ssl::SslConnector>,
 }
 
 impl SslContext {
@@ -23,24 +22,24 @@ impl SslContext {
               C: AsRef<Path>,
               K: AsRef<Path>
     {
-        let mut ctx: ssl::SslContext = try!(ssl::SslContext::new(SslMethod::Tlsv1_2));
-        try!(ctx.set_cipher_list("DEFAULT"));
-        try!(ctx.set_CA_file(ca.as_ref()));
+        let mut ctx_builder = try!(ssl::SslConnectorBuilder::new(SslMethod::tls()));
 
+        try!(ctx_builder.builder_mut().set_ca_file(ca.as_ref()));
         if let Some((cert, key)) = client_pair {
-            try!(ctx.set_certificate_file(cert, X509FileType::PEM));
-            try!(ctx.set_private_key_file(key, X509FileType::PEM));
+            try!(ctx_builder.builder_mut().set_certificate_file(cert, X509_FILETYPE_PEM));
+            try!(ctx_builder.builder_mut().set_private_key_file(key, X509_FILETYPE_PEM));
         }
         if should_verify_ca {
-            ctx.set_verify(SSL_VERIFY_PEER);
+            ctx_builder.builder_mut().set_verify(SSL_VERIFY_PEER);
         } else {
-            ctx.set_verify(SSL_VERIFY_NONE);
+            ctx_builder.builder_mut().set_verify(SSL_VERIFY_NONE);
         }
-        Ok(SslContext { inner: Arc::new(ctx) })
+
+        Ok(SslContext { inner: Arc::new(ctx_builder.build()) })
     }
 
     pub fn connect(&self, stream: TcpStream) -> Result<SslStream> {
-        let ssl_stream = try!(ssl::SslStream::connect(&*self.inner, stream));
+        let ssl_stream = try!(ssl::SslConnector::danger_connect_without_providing_domain_for_certificate_verification_and_server_name_indication(&*self.inner, stream));
         Ok(ssl_stream)
     }
 }


### PR DESCRIPTION
Bumps our rust-openssl library support to 0.9, which requires us to send along a domain name when connecting (or use a heavily-cautioned-against unsafe version) along with other minor api changes. We won't be able to support system openssl versions < 1.0.0 (which is why we no longer use a feature flag for tlsv1_2, all versions >=1.0.0 support it), but note that [versions < 1.0.2 are no longer supported and should not be used.](https://www.openssl.org/policies/releasestrat.html)